### PR TITLE
Another idx Win64 workaround.

### DIFF
--- a/utilities/iris_utils.py
+++ b/utilities/iris_utils.py
@@ -725,6 +725,7 @@ def get_nearest_water(cube, tree, xi, yi, k=10, max_dist=0.04, min_var=0.01):
     series, dist, idx = None, None, None
     IJs = list(zip(i, j))
     for dist, idx in zip(distances, IJs):
+        idx = tuple([int(k) for k in idx])
         if unstructured:  # NOTE: This would be so elegant in py3k!
             idx = (idx[0],)
         # This weird syntax allow for idx to be len 1 or 2.


### PR DESCRIPTION
@rsignell-usgs with this change I was able to run the notebook [here](http://nbviewer.ipython.org/urls/gist.githubusercontent.com/ocefpaf/e27255a5a8c5a1d6415c/raw/8cfd5da837df494d84a688e19bb27ed6a979941f/test_win64.ipynb).

This bug will probably re-appear in several places.  The real fix would be to find why iris thinks that an np.int64 is a tuple on Windows64...